### PR TITLE
Now full width is used for the device name under the spotify cover

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -69,10 +69,11 @@
 	font-weight: bold;
 	text-align: left;
 	float: left;
-	font-size: 12pt;
+	font-size: 10pt;
 	margin-left: 6px;
+	margin-top: 2px;
 	display: inline-block;
-	width: 170px !important;
+	width: 208px !important;
 	height: 25px;
 }
 
@@ -111,7 +112,7 @@
 	}
 
 	#spotify_device {
-		width: 130px !important;
+		width: 170px !important;
 	}
 
 	#spotify_table #timer {


### PR DESCRIPTION
I changed the width for `#spotify_device` and the front-size down to 10pt for better display of the device name.  
My device name (22 chars) was cut off.